### PR TITLE
BUGFIX: Ground Truth Translation is getting accumulated over time

### DIFF
--- a/core/datasets/dataset_train.py
+++ b/core/datasets/dataset_train.py
@@ -92,9 +92,11 @@ class DatasetTrain(Dataset):
                     'betas': self.betas[index].astype(np.float32)
                     }
         item['smpl_params'] = smpl_params
-        item['translation'] = self.cam_ext[index][:, 3]
+        translation = self.cam_ext[index][:, 3].copy()
         if 'trans_cam' in self.data.files:
-            item['translation'][:3] += self.trans_cam[index]
+            translation[:3] += self.trans_cam[index]
+        item['translation'] = translation
+
         img_patch_rgba = None
         img_patch_cv = None
         img_patch_rgba, \

--- a/core/datasets/dataset_train_hands.py
+++ b/core/datasets/dataset_train_hands.py
@@ -123,9 +123,10 @@ class DatasetTrain(Dataset):
         item['gt_body_verts'] = smplx_output_gt.body_verts[0].detach()
         item['gt_vertices'] = smplx_output_gt.vertices[0].detach()
 
-        item['translation'] = self.cam_ext[index][:, 3]
+        translation = self.cam_ext[index][:, 3].copy()
         if 'trans_cam' in self.data.files:
-            item['translation'][:3] += self.trans_cam[index]
+            translation[:3] += self.trans_cam[index]
+        item['translation'] = translation
 
         img_patch_rgba, \
         img_patch_cv, \


### PR DESCRIPTION
hello @pixelite1201 , there is a bug in the dataloaders where if the same data example gets picked over the different training epochs, we keep accumulating the camera translation, meaning if the same example gets picked two or more times during training, all the ground truth camera translations for those examples are wrong. Since ground truth translation then doesn't match, the training of the model will not converge correctly.

Small example that demonstrates the bug:

```
import numpy as np

cam_ext = np.zeros((2, 4, 4))
cam_ext[:, :, 3] = [[1, 2, 3, 4],
                    [10, 20, 30, 40]]

print(cam_ext)

def get_item(idx):
    item = {}
    item['translation'] = cam_ext[idx][:, 3]      

    item['translation'][:3] += np.array([0.5, 1.0, 1.5])  
    return item

print("start", cam_ext[0][:, 3])
get_item(0)
print("1st", cam_ext[0][:, 3])
get_item(0)
print("2nd", cam_ext[0][:, 3])
```

Output:
```
start [1. 2. 3. 4.]
1st [1.5 3.  4.5 4. ]
2nd [2. 4. 6. 4.]
```

so in the first `__getitem__` call the ground truth is correct, in the second call it is offset. This offset gets larger whenever `__getitem__` is called on the same data example.

As shown by the growing error throughout training

<img width="318" height="287" alt="image" src="https://github.com/user-attachments/assets/113b4762-d806-47dd-a824-d2f70dc1c43f" />

This PR addresses fixes the bug by making a copy of the translation and therefore not updating the original cam ext slice which is the root of the error.


